### PR TITLE
Fixed MD5

### DIFF
--- a/lib/chef/handler/jenkins.rb
+++ b/lib/chef/handler/jenkins.rb
@@ -24,7 +24,7 @@ class Chef
             updates << {
               "path" => res.path,
               "action" => res.action,
-              "md5" => Digest::MD5.hexdigest(IO.read(res.path)),
+              "md5" => Digest::MD5.file(res.path).hexdigest,
               "type" => res.class.name
             }
             # res.checksum is SHA1 sum


### PR DESCRIPTION
The MD5 computed by the jenkins chef handler didn't match the one in Jenkins, therefore the fingerprints tracking wasn't properly working.
